### PR TITLE
[#25] 응답 포맷 통일 및 상수화 + 토큰/결제 로직 정리

### DIFF
--- a/src/main/java/com/example/japtangjjigae/cart/controller/CartController.java
+++ b/src/main/java/com/example/japtangjjigae/cart/controller/CartController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,10 +31,11 @@ public class CartController {
         summary = "장바구니에 좌석 담기 api"
     )
     @PostMapping("/cart")
-    public ResponseEntity<String> addCart(
+    public ResponseEntity<ApiResponse<String>> addCart(
         @Valid @RequestBody AddSeatToCartRequestDTO requestDto) {
         cartService.addSeat(requestDto);
-        return ResponseEntity.ok("장바구니에 좌석 담기 완료");
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.from(TrainResponseCode.CART_CREATED));
     }
 
     @Operation(

--- a/src/main/java/com/example/japtangjjigae/global/response/code/TrainResponseCode.java
+++ b/src/main/java/com/example/japtangjjigae/global/response/code/TrainResponseCode.java
@@ -9,6 +9,7 @@ public enum TrainResponseCode implements ResponseCode {
 
     TRAIN_FOUND(200, "조건에 해당되는 기차 존재"),
     SEAT_FOUND(200, "조건에 해당되는 좌석 존재"),
+    CART_CREATED(201, "장바구니 담기 성공"),
     EXIST_SEAT(409, "해당 좌석 장바구니에 존재"),
     CONFLICT_SEAT(409, "다른 사람이 선택한 좌석"),
     MATCH_TRAIN_NOT_FOUND(404, "조건에 해당하는 기차 없음"),

--- a/src/main/java/com/example/japtangjjigae/jwt/JWTFilter.java
+++ b/src/main/java/com/example/japtangjjigae/jwt/JWTFilter.java
@@ -4,25 +4,23 @@ import com.example.japtangjjigae.oauth2.CustomOAuth2User;
 import com.example.japtangjjigae.user.common.OAuthProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Collections;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JWTFilter extends OncePerRequestFilter {
 
-    private static final String ACCESS_TOKEN_COOKIE_NAME = "Authorization";
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final JWTUtil jwtUtil;
 
@@ -70,11 +68,11 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     private String resolveAccessToken(HttpServletRequest request) {
-        String header = request.getHeader("Authorization");
+        String header = request.getHeader(AUTH_HEADER);
 
         if(header == null || header.isBlank()) return null;
 
-        if(!header.startsWith("Bearer ")) return null;
+        if(!header.startsWith(BEARER_PREFIX)) return null;
 
         return header.substring(7);
     }

--- a/src/main/java/com/example/japtangjjigae/jwt/JWTUtil.java
+++ b/src/main/java/com/example/japtangjjigae/jwt/JWTUtil.java
@@ -14,6 +14,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class JWTUtil {
 
+    private static final String CATEGORY = "category";
+    private static final String USER_ID = "userId";
+    private static final String OAUTH_PROVIDER = "oAuthProvider";
+
     private final SecretKey secretKey;
     private final JwtParser jwtParser;
 
@@ -26,19 +30,20 @@ public class JWTUtil {
     }
 
     public TokenCategory getCategory(String token) {
-        return jwtParser.parseSignedClaims(token).getPayload().get("category", TokenCategory.class);
+        String raw = jwtParser.parseSignedClaims(token).getPayload().get(CATEGORY, String.class);
+        return TokenCategory.valueOf(raw);
     }
 
     public Long getUserId(String token) {
         return jwtParser.parseSignedClaims(token)
             .getPayload()
-            .get("userId", Long.class);
+            .get(USER_ID, Long.class);
     }
 
     public OAuthProvider getOAuthProvider(String token) {
         String provider = jwtParser.parseSignedClaims(token)
             .getPayload()
-            .get("oAuthProvider", String.class);
+            .get(OAUTH_PROVIDER, String.class);
 
         return OAuthProvider.valueOf(provider);
     }
@@ -54,9 +59,9 @@ public class JWTUtil {
     public String createJwt(TokenCategory category, Long userId, OAuthProvider oAuthProvider,
         long expiredSeconds) {
         return Jwts.builder()
-            .claim("category", category)
-            .claim("userId", userId)
-            .claim("oAuthProvider", oAuthProvider.name())
+            .claim(CATEGORY, category.name())
+            .claim(USER_ID, userId)
+            .claim(OAUTH_PROVIDER, oAuthProvider.name())
             .issuedAt(new Date(System.currentTimeMillis()))
             .expiration(new Date(System.currentTimeMillis() + expiredSeconds * 1000))
             .signWith(secretKey)

--- a/src/main/java/com/example/japtangjjigae/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/example/japtangjjigae/oauth2/CustomOAuth2FailureHandler.java
@@ -23,7 +23,7 @@ public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler 
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
-        AuthenticationException exception) throws IOException, ServletException {
+        AuthenticationException exception) throws IOException {
 
         ResponseCode responseCode = resolveResponseCode(exception);
 

--- a/src/main/java/com/example/japtangjjigae/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/example/japtangjjigae/oauth2/CustomOAuth2SuccessHandler.java
@@ -24,6 +24,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String COOKIE_HEADER = "Set-Cookie";
+
     private final JWTUtil jwtUtil;
     private final ObjectMapper objectMapper;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -62,11 +66,11 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         String refreshToken = jwtUtil.createJwt(TokenCategory.REFRESH, userId, oAuthProvider,
             TokenTTL.REFRESH.seconds());
         String accessToken =
-            "Bearer " + jwtUtil.createJwt(TokenCategory.ACCESS, userId, oAuthProvider,
+            BEARER_PREFIX + jwtUtil.createJwt(TokenCategory.ACCESS, userId, oAuthProvider,
                 TokenTTL.ACCESS.seconds());
 
-        response.setHeader("Authorization", accessToken);
-        response.addHeader("Set-Cookie",
+        response.setHeader(AUTH_HEADER, accessToken);
+        response.addHeader(COOKIE_HEADER,
             TokenCookie.buildRefreshCookie(refreshToken, TokenTTL.REFRESH.seconds()));
 
         saveRefreshToken(userId, refreshToken);

--- a/src/main/java/com/example/japtangjjigae/train/dto/SeatSearchResponseDTO.java
+++ b/src/main/java/com/example/japtangjjigae/train/dto/SeatSearchResponseDTO.java
@@ -17,6 +17,8 @@ public class SeatSearchResponseDTO {
     @Builder
     public static class TrainSummary {
         private String trainCode;
+        private Long originStopId;
+        private Long destinationStopId;
         private String originCode;
         private LocalTime departureAt;
         private String destinationCode;

--- a/src/main/java/com/example/japtangjjigae/train/service/TrainService.java
+++ b/src/main/java/com/example/japtangjjigae/train/service/TrainService.java
@@ -153,7 +153,9 @@ public class TrainService {
 
         TrainSummary trainSummary = TrainSummary.builder()
             .trainCode(trainRun.getTrain().getTrainCode())
+            .originStopId(departureStop.getId())
             .originCode(request.getOriginStationCode())
+            .destinationStopId(arrivalStop.getId())
             .destinationCode(request.getDestinationStationCode())
             .build();
 

--- a/src/main/java/com/example/japtangjjigae/user/controller/LoginController.java
+++ b/src/main/java/com/example/japtangjjigae/user/controller/LoginController.java
@@ -17,11 +17,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -30,6 +28,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1")
 public class LoginController {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String COOKIE_HEADER = "Set-Cookie";
 
     private final LoginService loginService;
     private final TokenService tokenService;
@@ -57,8 +58,8 @@ public class LoginController {
         String[] tokens = tokenService.issueAccessTokenRefreshToken(request);
         String accessToken = tokens[0];
         String refreshToken = tokens[1];
-        response.setHeader("Authorization", accessToken);
-        response.addHeader("Set-Cookie", TokenCookie.buildRefreshCookie(refreshToken, TokenTTL.REFRESH.seconds()));
+        response.setHeader(AUTH_HEADER, accessToken);
+        response.addHeader(COOKIE_HEADER, TokenCookie.buildRefreshCookie(refreshToken, TokenTTL.REFRESH.seconds()));
 
         return ResponseEntity.status(HttpStatus.OK).body(accessToken);
     }


### PR DESCRIPTION
- CartController: 장바구니 담기 API 응답 변경
- OAuth2FailureHandler: 불필요한 throws 제거
- OAuth2SuccessHandler/JWTFilter/LoginController: 헤더/프리픽스 상수화
- JWTUtil: claim key 상수화 + category 파싱 안정화
- KakaoPayProvider: total_amount 계산 수정 + tid 조회 Optional 처리 + 상수/로그 정리
- TrainService: seatSearch 응답에 origin/destination stopId 포함