### PR TITLE
[CHORE] profile 그룹 정리 및 local/prod 설정 분리

### DIFF
--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -1,0 +1,19 @@
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+
+kakaopay:
+  cid : TC0ONETIME

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,45 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${MYSQL_HOST}/jjigae?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: ${MYSQL_USER}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jwt:
+    secret: ${JWT_SECRET}
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_REST_API_KEY}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Naver
+
+kakaopay:
+  secretKey: ${KAKAOPAY_SECRET_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,32 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: 6379
+
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Kakao
+
+          naver:
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            client-name: Naver
+
+server:
+  forward-headers-strategy: framework

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,17 +2,9 @@ spring:
   profiles:
     active: local
     group:
-      local: local, common, secret
-      blue: blue, common, secret
-      green: green, common, secret
-#  jpa:
-#    properties:
-#      hibernate:
-#        generate_statistics: true
-#        session:
-#          events:
-#            log:
-#              LOG_QUERIES_SLOWER_THAN_MS: 200
+      local: local, common
+      blue: blue, common, prod
+      green: green, common, prod
 
 server:
   env: blue
@@ -20,12 +12,6 @@ server:
     encoding:
       charset: utf-8
       force: true
-
-#logging:
-#  level:
-#    org.hibernate.SQL: debug
-#    org.hibernate.orm.jdbc.bind: trace
-#    org.hibernate.stat: debug
 
 ---
 


### PR DESCRIPTION
- profil group 재정의
- OAuth2 provider/registration, KakaoPay 설정 분리
- datasource/redis/jpa/jwt 설정을 환경별로 분리
- prod에서 redirect-uri를 {baseUrl} 기반으로 변경,
  forward-headers-strategy 추가
