### PR TITLE
[Perf] Redis 좌석 홀드 조회 최적화 및 TrainRun 검색 쿼리 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ bin/
 scripts/
 src/main/java/com/example/japtangjjigae/global/init/TrainDataInitializerLoadTest.java
 /src/main/java/com/example/japtangjjigae/global/init/SeatHoldPreSeeder.java
+/src/main/java/com/example/japtangjjigae/global/init/TrainDataInitializerLarge.java
 /summary-seats.json
 /summary-trains.json

--- a/src/main/java/com/example/japtangjjigae/redis/seathold/RedisSeatHoldStore.java
+++ b/src/main/java/com/example/japtangjjigae/redis/seathold/RedisSeatHoldStore.java
@@ -12,10 +12,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class RedisSeatHoldStore extends AbstractRedisStore implements SeatHoldStore {
 
-    //구간별 인덱스 key
+    //구간별 인덱스 key => 조회 시 모든 좌석 다 검사하지 않기 위함(후보 seatID 목록 빨리 얻기 위한 보조)
     private static final String INDEX_PREFIX = "seat-hold-index:";
 
-    //구간 겹침 위한 key
+    //구간 겹침 체크를 위한 key
     private static final String SEG_PREFIX = "seat-hold-orders:";
 
     /**

--- a/src/main/java/com/example/japtangjjigae/redis/seathold/RedisSeatHoldStore.java
+++ b/src/main/java/com/example/japtangjjigae/redis/seathold/RedisSeatHoldStore.java
@@ -2,6 +2,7 @@ package com.example.japtangjjigae.redis.seathold;
 
 import com.example.japtangjjigae.redis.AbstractRedisStore;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -11,21 +12,42 @@ import org.springframework.stereotype.Component;
 @Component
 public class RedisSeatHoldStore extends AbstractRedisStore implements SeatHoldStore {
 
-    private static final String KEY_PREFIX = "seat-hold:";
+    //구간별 인덱스 key
     private static final String INDEX_PREFIX = "seat-hold-index:";
 
-    private static final String SEG_PREFIX = "seat-hold-seg:";
+    //구간 겹침 위한 key
+    private static final String SEG_PREFIX = "seat-hold-orders:";
 
-    private final DefaultRedisScript<Long> holdMultiScript = new DefaultRedisScript<>("""
-          for i=1,#KEYS do
-            if redis.call('EXISTS', KEYS[i]) == 1 then
-              return 0
-            end
+    /**
+     * 1. 이미 홀드된 구간 있으면 즉시 실패
+     * 2. 전부 비어있으면 세그먼트 키를 전부 SET + TTL
+     * 3. KEYS[i] 문자열을 파싱해서 인덱스 Set에도 seatId를 넣음
+     */
+    private final DefaultRedisScript<Long> holdMultiScript2 = new DefaultRedisScript<>("""
+        for i=1,#KEYS do
+          if redis.call('EXISTS', KEYS[i]) == 1 then
+            return 0
           end
-          for i=1,#KEYS do
-            redis.call('SET', KEYS[i], ARGV[1], 'EX', ARGV[2])
+        end
+
+        for i=1,#KEYS do
+          redis.call('SET', KEYS[i], ARGV[1], 'EX', ARGV[2])
+
+          -- KEYS[i] = seat-hold-orders:{trainRunId}:{seatId}:{order}
+          local parts = {}
+          for part in string.gmatch(KEYS[i], "([^:]+)") do
+            table.insert(parts, part)
           end
-          return 1
+
+          local trainRunId = parts[2]
+          local seatId = parts[3]
+          local order = parts[4]
+
+          local indexKey = "seat-hold-index:" .. trainRunId .. ":" .. order
+          redis.call('SADD', indexKey, seatId)
+        end
+
+        return 1
         """, Long.class);
 
     public RedisSeatHoldStore(StringRedisTemplate stringRedisTemplate) {
@@ -37,11 +59,12 @@ public class RedisSeatHoldStore extends AbstractRedisStore implements SeatHoldSt
         long ttlSeconds) {
         List<String> keys = new ArrayList<>();
         for (Long seatId : seatIds) {
-            for (int seg = depOrder; seg < arrOrder; seg++) {
-                keys.add(SEG_PREFIX + trainRunId + ":" + seatId + ":" + seg);
+            for (int order = depOrder; order < arrOrder; order++) {
+                keys.add(SEG_PREFIX + trainRunId + ":" + seatId + ":" + order);
             }
         }
-        Long result = stringRedisTemplate.execute(holdMultiScript, keys, String.valueOf(userId),
+
+        Long result = stringRedisTemplate.execute(holdMultiScript2, keys, String.valueOf(userId),
             String.valueOf(ttlSeconds));
         return result != null && result == 1L;
     }
@@ -49,55 +72,56 @@ public class RedisSeatHoldStore extends AbstractRedisStore implements SeatHoldSt
     @Override
     public List<SeatHold> findOverLappingHolds(Long trainRunId, int requestDepartureOrder,
         int requestArrivalOrder) {
-        String indexKey = INDEX_PREFIX + trainRunId;
-        Set<String> seatIdStrs = getSetMembers(indexKey);
-        if (seatIdStrs == null || seatIdStrs.isEmpty()) {
-            return List.of();
-        }
+        Set<Long> overlappedSeatIds = new HashSet<>();
 
-        List<String> seatKeys = seatIdStrs.stream()
-            .map(seatIdStr -> KEY_PREFIX + trainRunId + ":" + seatIdStr)
-            .toList();
+        for (int order = requestDepartureOrder; order < requestArrivalOrder; order++) {
+            int currentOrder = order;
+            String indexKey = INDEX_PREFIX + trainRunId + ":" + currentOrder;
 
-        List<String> values = stringRedisTemplate.opsForValue().multiGet(seatKeys);
+            Set<String> seatIdStrs = getSetMembers(indexKey);
+            if (seatIdStrs == null || seatIdStrs.isEmpty()) continue;
 
-        List<SeatHold> holds = new ArrayList<>();
-        List<String> expiredSeatIdsToRemove = new ArrayList<>();
+            List<String> seatIdList = new ArrayList<>(seatIdStrs);
+            List<String> segKeys = seatIdList.stream()
+                .map(seatIdStr -> SEG_PREFIX + trainRunId + ":" + seatIdStr + ":" + currentOrder)
+                .toList();
 
-        int i = 0;
-        for (String seatIdStr : seatIdStrs) {
-            String v = (values != null ? values.get(i) : null);
-            i++;
+            List<String> values = stringRedisTemplate.opsForValue().multiGet(segKeys);
 
-            if (v == null) {
-                expiredSeatIdsToRemove.add(seatIdStr);
-                continue;
+            List<String> expiredToRemove = new ArrayList<>();
+            for (int i = 0; i < seatIdList.size(); i++) {
+                String seatIdStr = seatIdList.get(i);
+                String v = (values != null ? values.get(i) : null);
+
+                if (v == null) {
+                    expiredToRemove.add(seatIdStr);
+                } else {
+                    overlappedSeatIds.add(Long.valueOf(seatIdStr));
+                }
             }
 
-            String[] parts = v.split(":");
-            int depOrder = Integer.parseInt(parts[0]);
-            int arrOrder = Integer.parseInt(parts[1]);
-
-            if (depOrder < requestArrivalOrder && requestDepartureOrder < arrOrder) {
-                holds.add(new SeatHold(Long.valueOf(seatIdStr), depOrder, arrOrder));
+            if (!expiredToRemove.isEmpty()) {
+                stringRedisTemplate.opsForSet().remove(indexKey, expiredToRemove.toArray());
             }
         }
 
-        if (!expiredSeatIdsToRemove.isEmpty()) {
-            stringRedisTemplate.opsForSet().remove(indexKey, expiredSeatIdsToRemove.toArray());
+        List<SeatHold> result = new ArrayList<>();
+        for (Long seatId : overlappedSeatIds) {
+            result.add(new SeatHold(seatId, requestDepartureOrder, requestArrivalOrder));
         }
-
-        return holds;
+        return result;
     }
 
     @Override
     public void releaseSeat(Long trainRunId, List<Long> seatIds, int depOrder, int arrOrder) {
-        List<String> keys = new ArrayList<>();
+        List<String> segKeys = new ArrayList<>();
         for (Long seatId : seatIds) {
-            for (int seg = depOrder; seg < arrOrder; seg++) {
-                keys.add(SEG_PREFIX + trainRunId + ":" + seatId + ":" + seg);
+            for (int order = depOrder; order < arrOrder; order++) {
+                segKeys.add(SEG_PREFIX + trainRunId + ":" + seatId + ":" + order);
+                String indexKey = INDEX_PREFIX + trainRunId + ":" + order;
+                stringRedisTemplate.opsForSet().remove(indexKey, String.valueOf(seatId));
             }
         }
-        stringRedisTemplate.delete(keys);
+        stringRedisTemplate.delete(segKeys);
     }
 }

--- a/src/main/java/com/example/japtangjjigae/ticket/repository/TicketRepository.java
+++ b/src/main/java/com/example/japtangjjigae/ticket/repository/TicketRepository.java
@@ -10,31 +10,31 @@ import org.springframework.data.repository.query.Param;
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     @Query("""
-        select count(distinct t.seat.id)
-        from Ticket t
+          select count(distinct t.seat.id)
+          from Ticket t
             join t.departureStop ds
             join t.arrivalStop arr
-        where t.trainRun = :trainRun
-          and ds.stopOrder < :requestArrivalOrder
-          and :requestDepartureOrder < arr.stopOrder
-          and t.deletedAt is null
+          where t.trainRun.id = :trainRunId
+            and ds.stopOrder < :requestArrivalOrder
+            and :requestDepartureOrder < arr.stopOrder
+            and t.deletedAt is null
         """)
     int countBookedSeatsInSection(
-        @Param("trainRun") TrainRun trainRun,
+        @Param("trainRunId") Long trainRunId,
         @Param("requestDepartureOrder") int requestDepartureOrder,
         @Param("requestArrivalOrder") int requestArrivalOrder
     );
 
     @Query("""
-    select distinct t.seat.id
-    from Ticket t
-        join t.departureStop ds
-        join t.arrivalStop arr
-    where t.trainRun = :trainRun
-      and ds.stopOrder < :requestArrivalOrder
-      and :requestDepartureOrder < arr.stopOrder
-      and t.deletedAt is null
-""")
+            select distinct t.seat.id
+            from Ticket t
+                join t.departureStop ds
+                join t.arrivalStop arr
+            where t.trainRun = :trainRun
+              and ds.stopOrder < :requestArrivalOrder
+              and :requestDepartureOrder < arr.stopOrder
+              and t.deletedAt is null
+        """)
     List<Long> findBookedSeatIdsInSection(
         @Param("trainRun") TrainRun trainRun,
         @Param("requestDepartureOrder") int requestDepartureOrder,

--- a/src/main/java/com/example/japtangjjigae/train/dto/TrainRunSearchRow.java
+++ b/src/main/java/com/example/japtangjjigae/train/dto/TrainRunSearchRow.java
@@ -1,0 +1,15 @@
+package com.example.japtangjjigae.train.dto;
+
+import java.time.LocalTime;
+
+public record TrainRunSearchRow (
+    Long trainRunId,
+    Long trainId,
+    String trainCode,
+    LocalTime departureAt,
+    LocalTime arrivalAt,
+    int departureOrder,
+    int arrivalOrder,
+    int departureFare,
+    int arrivalFare
+) {}

--- a/src/main/java/com/example/japtangjjigae/train/entity/TrainRun.java
+++ b/src/main/java/com/example/japtangjjigae/train/entity/TrainRun.java
@@ -42,4 +42,8 @@ public class TrainRun {
     public Train getTrain() {
         return train;
     }
+
+    public LocalDate getRunDate(){
+        return runDate;
+    }
 }

--- a/src/main/java/com/example/japtangjjigae/train/repository/SeatRepository.java
+++ b/src/main/java/com/example/japtangjjigae/train/repository/SeatRepository.java
@@ -11,5 +11,6 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
     List<Seat> findByCarriageInOrderByCarriage_IdAscRowNumberAscColumnCodeAsc(List<Carriage> carriages);
 
     int countByCarriage_Train(Train train);
+    int countByCarriage_Train_Id(Long trainId);
     List<Seat> findByCarriage_Train(Train train);
 }

--- a/src/main/java/com/example/japtangjjigae/train/repository/TrainRunRepository.java
+++ b/src/main/java/com/example/japtangjjigae/train/repository/TrainRunRepository.java
@@ -1,5 +1,6 @@
 package com.example.japtangjjigae.train.repository;
 
+import com.example.japtangjjigae.train.dto.TrainRunSearchRow;
 import com.example.japtangjjigae.train.entity.TrainRun;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -13,30 +14,41 @@ public interface TrainRunRepository extends JpaRepository<TrainRun, Long> {
 
     @Query(
         value = """
-        select distinct tr
-        from TrainStop s1
-        join TrainStop s2 on s1.trainRun = s2.trainRun
-        join s1.trainRun tr
-        where s1.station.code = :originStationCode
-          and s2.station.code = :destinationStationCode
-          and tr.runDate = :runDate
-          and s1.stopOrder < s2.stopOrder
-          and s1.departureAt >= :departureTime
-        order by s1.departureAt
-        """,
+              select TrainRunSearchRow(
+                tr.id,
+                t.id,
+                t.trainCode,
+                s1.departureAt,
+                s2.arrivalAt,
+                s1.stopOrder,
+                s2.stopOrder,
+                s1.cumulativeFare,
+                s2.cumulativeFare
+              )
+              from TrainStop s1
+              join TrainStop s2 on s1.trainRun = s2.trainRun
+              join s1.trainRun tr
+              join tr.train t
+              where s1.station.code = :originStationCode
+                and s2.station.code = :destinationStationCode
+                and tr.runDate = :runDate
+                and s1.stopOrder < s2.stopOrder
+                and s1.departureAt >= :departureTime
+              order by s1.departureAt
+            """,
         countQuery = """
-        select count(distinct tr)
-        from TrainStop s1
-        join TrainStop s2 on s1.trainRun = s2.trainRun
-        join s1.trainRun tr
-        where s1.station.code = :originStationCode
-          and s2.station.code = :destinationStationCode
-          and tr.runDate = :runDate
-          and s1.stopOrder < s2.stopOrder
-          and s1.departureAt >= :departureTime
-        """
+              select count(distinct tr)
+              from TrainStop s1
+              join TrainStop s2 on s1.trainRun = s2.trainRun
+              join s1.trainRun tr
+              where s1.station.code = :originStationCode
+                and s2.station.code = :destinationStationCode
+                and tr.runDate = :runDate
+                and s1.stopOrder < s2.stopOrder
+                and s1.departureAt >= :departureTime
+            """
     )
-    Page<TrainRun> findTrainRuns(
+    Page<TrainRunSearchRow> findTrainRunRows(
         @Param("originStationCode") String originStationCode,
         @Param("destinationStationCode") String destinationStationCode,
         @Param("runDate") LocalDate runDate,

--- a/src/main/java/com/example/japtangjjigae/train/service/TrainService.java
+++ b/src/main/java/com/example/japtangjjigae/train/service/TrainService.java
@@ -12,6 +12,7 @@ import com.example.japtangjjigae.train.dto.SeatSearchResponseDTO.CarriageSeatDTO
 import com.example.japtangjjigae.train.dto.SeatSearchResponseDTO.SeatDTO;
 import com.example.japtangjjigae.train.dto.SeatSearchResponseDTO.TrainSummary;
 import com.example.japtangjjigae.train.dto.TrainInfoDTO;
+import com.example.japtangjjigae.train.dto.TrainRunSearchRow;
 import com.example.japtangjjigae.train.dto.TrainSearchRequestDTO;
 import com.example.japtangjjigae.train.dto.TrainSearchResponseDTO;
 import com.example.japtangjjigae.train.entity.Carriage;
@@ -53,33 +54,20 @@ public class TrainService {
         String destinationCode = request.getDestinationStationCode();
 
         Pageable pageable = PageRequest.of(page, 10);
-        Page<TrainRun> pageTrainRuns = trainRunRepository.findTrainRuns(
-            originCode,
-            destinationCode,
-            request.getRunDate(),
-            request.getDepartureTime(), pageable);
-        List<TrainRun> trainRuns = pageTrainRuns.getContent();
+        Page<TrainRunSearchRow> pageRows = trainRunRepository.findTrainRunRows(
+            originCode, destinationCode, request.getRunDate(), request.getDepartureTime(), pageable);
 
         List<TrainInfoDTO> trains = new ArrayList<>();
 
-        for (TrainRun trainRun : trainRuns) {
-            TrainStop departureTrainStop = getTrainStop(trainRun, originCode);
-            TrainStop arrivalTrainStop = getTrainStop(trainRun, destinationCode);
-
-            boolean soldOut = isSoldOut(
-                trainRun,
-                departureTrainStop.getStopOrder(),
-                arrivalTrainStop.getStopOrder()
-            );
-
-            int price =
-                arrivalTrainStop.getCumulativeFare() - departureTrainStop.getCumulativeFare();
+        for (TrainRunSearchRow row : pageRows.getContent()) {
+            boolean soldOut = isSoldOut(row.trainRunId(), row.trainId(), row.departureOrder(), row.arrivalOrder());
+            int price = row.arrivalFare() - row.departureFare();
 
             trains.add(new TrainInfoDTO(
-                trainRun.getId(),
-                trainRun.getTrain().getTrainCode(),
-                departureTrainStop.getDepartureAt(),
-                arrivalTrainStop.getArrivalAt(),
+                row.trainRunId(),
+                row.trainCode(),
+                row.departureAt(),
+                row.arrivalAt(),
                 price,
                 soldOut
             ));
@@ -88,12 +76,12 @@ public class TrainService {
         return new TrainSearchResponseDTO(originCode, destinationCode, trains);
     }
 
-    private boolean isSoldOut(TrainRun trainRun, int departureOrder, int arrivalOrder) {
-        int totalSeats = seatRepository.countByCarriage_Train(trainRun.getTrain());
-        int bookedSeats = ticketRepository.countBookedSeatsInSection(trainRun, departureOrder,
+    private boolean isSoldOut(Long trainRunId, Long trainId, int departureOrder, int arrivalOrder) {
+        int totalSeats = seatRepository.countByCarriage_Train_Id(trainId);
+        int bookedSeats = ticketRepository.countBookedSeatsInSection(trainRunId, departureOrder,
             arrivalOrder);
 
-        List<SeatHold> holdSeats = seatHoldStore.findOverLappingHolds(trainRun.getId(),
+        List<SeatHold> holdSeats = seatHoldStore.findOverLappingHolds(trainRunId,
             departureOrder, arrivalOrder);
 
         int holdSeatCount = (int) holdSeats.stream()

--- a/src/test/java/com/example/japtangjjigae/train/service/TrainServiceTest.java
+++ b/src/test/java/com/example/japtangjjigae/train/service/TrainServiceTest.java
@@ -1,0 +1,299 @@
+package com.example.japtangjjigae.train.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.mock;
+
+import com.example.japtangjjigae.order.Order;
+import com.example.japtangjjigae.redis.seathold.SeatHoldStore;
+import com.example.japtangjjigae.redis.seathold.SeatHoldStore.SeatHold;
+import com.example.japtangjjigae.station.repository.StationRepository;
+import com.example.japtangjjigae.ticket.PayStatus;
+import com.example.japtangjjigae.ticket.entity.Ticket;
+import com.example.japtangjjigae.ticket.repository.TicketRepository;
+import com.example.japtangjjigae.train.dto.TrainInfoDTO;
+import com.example.japtangjjigae.train.dto.TrainSearchRequestDTO;
+import com.example.japtangjjigae.train.dto.TrainSearchResponseDTO;
+import com.example.japtangjjigae.train.entity.Carriage;
+import com.example.japtangjjigae.train.entity.Seat;
+import com.example.japtangjjigae.train.entity.Train;
+import com.example.japtangjjigae.train.entity.TrainRun;
+import com.example.japtangjjigae.train.entity.TrainStop;
+import com.example.japtangjjigae.train.repository.CarriageRepository;
+import com.example.japtangjjigae.train.repository.SeatRepository;
+import com.example.japtangjjigae.train.repository.TrainRunRepository;
+import com.example.japtangjjigae.train.repository.TrainStopRepository;
+import com.example.japtangjjigae.user.common.OAuthProvider;
+import com.example.japtangjjigae.user.entity.User;
+import com.example.japtangjjigae.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class TrainServiceTest {
+
+    private static final String SEOUL = "SEOUL";
+    private static final String SUWON = "SUWON";
+    private static final String DAEJEON = "DAEJEON";
+    private static final String BUSAN = "BUSAN";
+
+    @Autowired
+    private TrainService trainService;
+    @Autowired
+    private TrainRunRepository trainRunRepository;
+    @Autowired
+    private TrainStopRepository trainStopRepository;
+    @Autowired
+    private CarriageRepository carriageRepository;
+    @Autowired
+    private SeatRepository seatRepository;
+    @Autowired
+    private TicketRepository ticketRepository;
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired private EntityManager em;
+
+    @MockitoBean
+    private SeatHoldStore seatHoldStore;
+
+    @BeforeEach
+    void setUp() {
+        // 기본은 홀드 없음
+        given(seatHoldStore.findOverLappingHolds(anyLong(), anyInt(), anyInt()))
+            .willReturn(List.of());
+    }
+
+    @Test
+    @DisplayName("searchTrain - 구간겹침 예약 내역으로 soldout")
+    void searchTrain_soldOut_byOverlappingTickets() {
+        //given
+        LocalDate runDate = LocalDate.now().plusDays(1);
+        TrainRun gb101 = getTrainRun(runDate, "GB101");
+
+        TrainSearchRequestDTO req = new TrainSearchRequestDTO(SEOUL, DAEJEON, runDate, LocalTime.of(0, 0), 1);
+
+        TrainStop ticketDep = getStop(gb101, SUWON);
+        TrainStop ticketArr = getStop(gb101, BUSAN);
+
+        User user = persistTestUser();
+        bookAllSeatsWithOrder(user, gb101, ticketDep, ticketArr);
+
+        TrainSearchResponseDTO res = trainService.searchTrain(req, 0);
+
+        // when & then
+        TrainInfoDTO gb101Info = findTrain(res, "GB101");
+        assertThat(gb101Info.isSoldOut()).isTrue();
+
+        TrainInfoDTO gb103Info = findTrain(res, "GB103");
+        assertThat(gb103Info.isSoldOut()).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("searchTrain - 구간겹침 홀드 내역으로 soldout")
+    void searchTrain_soldOut_byOverlappingHolds() {
+        //given
+        LocalDate runDate = LocalDate.now().plusDays(1);
+        TrainRun gb101 = getTrainRun(runDate, "GB101");
+
+        TrainSearchRequestDTO req = new TrainSearchRequestDTO(SEOUL, DAEJEON, runDate, LocalTime.of(0, 0), 1);
+
+        int holdDepOrder = getStop(gb101, SUWON).getStopOrder();
+        int holdArrOrder = getStop(gb101, BUSAN).getStopOrder();
+
+        List<Long> seatIds = getAllSeatIds(gb101.getTrain());
+        List<HoldMeta> stored = seatIds.stream()
+            .map(seatId -> new HoldMeta(gb101.getId(), seatId, holdDepOrder, holdArrOrder))
+            .toList();
+
+        stubSeatHoldStoreLikeRealOverlapFiltering(stored);
+
+        TrainSearchResponseDTO res = trainService.searchTrain(req, 0);
+
+        // when & then
+        TrainInfoDTO gb101Info = findTrain(res, "GB101");
+        assertThat(gb101Info.isSoldOut()).isTrue();
+    }
+
+    @Test
+    @DisplayName("searchTrain - 경계선으로 안겹치는 예약 내역과 함께 조회 성공")
+    void searchTrain_success_whenTicketTouchesBoundary() {
+        //given
+        LocalDate runDate = LocalDate.now().plusDays(1);
+        TrainRun gb101 = getTrainRun(runDate, "GB101");
+
+        TrainSearchRequestDTO req = new TrainSearchRequestDTO(SEOUL, SUWON, runDate, LocalTime.of(0, 0), 1);
+
+        TrainStop ticketDep = getStop(gb101, SUWON);
+        TrainStop ticketArr = getStop(gb101, DAEJEON);
+
+        User user = persistTestUser();
+        bookAllSeatsWithOrder(user, gb101, ticketDep, ticketArr);
+
+        TrainSearchResponseDTO res = trainService.searchTrain(req, 0);
+
+        // when & then
+        TrainInfoDTO gb101Info = findTrain(res, "GB101");
+        assertThat(gb101Info.isSoldOut()).isFalse();
+    }
+
+    @Test
+    @DisplayName("searchTrain - 경계선으로 안겹치는 홀드 내역과 함께 조회 성공")
+    void searchTrain_success_whenHoldTouchesBoundary() {
+        //given
+        LocalDate runDate = LocalDate.now().plusDays(1);
+        TrainRun gb101 = getTrainRun(runDate, "GB101");
+
+        TrainSearchRequestDTO req = new TrainSearchRequestDTO(SEOUL, SUWON, runDate, LocalTime.of(0, 0), 1);
+
+        int holdDepOrder = getStop(gb101, SUWON).getStopOrder();   // 2
+        int holdArrOrder = getStop(gb101, DAEJEON).getStopOrder(); // 3
+
+        List<Long> seatIds = getAllSeatIds(gb101.getTrain());
+        List<HoldMeta> stored = seatIds.stream()
+            .map(seatId -> new HoldMeta(gb101.getId(), seatId, holdDepOrder, holdArrOrder))
+            .toList();
+
+        stubSeatHoldStoreLikeRealOverlapFiltering(stored);
+
+        TrainSearchResponseDTO res = trainService.searchTrain(req, 0);
+
+        // when & then
+        TrainInfoDTO gb101Info = findTrain(res, "GB101");
+        assertThat(gb101Info.isSoldOut()).isFalse();
+    }
+
+    @Test
+    @DisplayName("searchTrain - 조건에 해당되는 기차 없는 경우")
+    void searchTrain_empty_whenNoMatchingTrains() {
+        //given
+        LocalDate runDateWithNoData = LocalDate.now().plusDays(30);
+
+        TrainSearchRequestDTO req = new TrainSearchRequestDTO(SEOUL, BUSAN, runDateWithNoData, LocalTime.of(0, 0), 1);
+
+        TrainSearchResponseDTO res = trainService.searchTrain(req, 0);
+
+        // when & then
+        assertThat(res.getTrains()).isEmpty();
+    }
+
+
+    private void bookAllSeatsWithOrder(User user, TrainRun run, TrainStop dep, TrainStop arr) {
+        List<Seat> seats = getAllSeats(run.getTrain());
+        int amount = arr.getCumulativeFare() - dep.getCumulativeFare();
+
+        List<Ticket> tickets = new ArrayList<>(seats.size());
+        for (Seat seat : seats) {
+            Ticket t = Ticket.createTicket(run, dep, arr, seat, amount);
+            tickets.add(t);
+        }
+
+        Order order = Order.createOrder(user, tickets, PayStatus.COMPLETE);
+
+        em.persist(order);
+        em.flush();
+
+        ticketRepository.flush();
+    }
+
+    private User persistTestUser() {
+        String socialId = "sid-" + UUID.randomUUID();
+        String phone = "010" + (int)(Math.random() * 1_0000_0000);
+
+        User u = User.createUser(socialId, OAuthProvider.KAKAO, "tester", phone);
+        userRepository.save(u);
+        userRepository.flush();
+        return u;
+    }
+
+    // -------------------------
+    // SeatHoldStore 스텁(겹침 필터링처럼)
+    // -------------------------
+    private void stubSeatHoldStoreLikeRealOverlapFiltering(List<HoldMeta> stored) {
+        willAnswer(inv -> {
+            long trainRunId = inv.getArgument(0);
+            int reqDep = inv.getArgument(1);
+            int reqArr = inv.getArgument(2);
+
+            // 겹침 조건: holdDep < reqArr && reqDep < holdArr
+            return stored.stream()
+                .filter(h -> h.trainRunId == trainRunId)
+                .filter(h -> h.departureOrder < reqArr && reqDep < h.arrivalOrder)
+                .map(h -> mockSeatHold(h.seatId))
+                .toList();
+        }).given(seatHoldStore).findOverLappingHolds(anyLong(), anyInt(), anyInt());
+    }
+
+    private SeatHold mockSeatHold(long seatId) {
+        SeatHold hold = mock(SeatHold.class);
+        given(hold.seatId()).willReturn(seatId);
+        return hold;
+    }
+
+    // -------------------------
+    // 초기데이터 조회 헬퍼
+    // -------------------------
+    private TrainRun getTrainRun(LocalDate runDate, String trainCode) {
+        return trainRunRepository.findAll().stream()
+            .filter(tr -> tr.getRunDate().equals(runDate))
+            .filter(tr -> tr.getTrain() != null && trainCode.equals(tr.getTrain().getTrainCode()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("초기 데이터에서 " + trainCode + " TrainRun을 찾지 못함"));
+    }
+
+    private TrainStop getStop(TrainRun run, String stationCode) {
+        return trainStopRepository.findByTrainRunAndStation_Code(run, stationCode)
+            .orElseThrow(() -> new IllegalStateException("TrainStop 없음: " + stationCode));
+    }
+
+    private List<Seat> getAllSeats(Train train) {
+        List<Carriage> carriages = carriageRepository.findByTrainOrderByCarriageNumberAsc(train);
+        return seatRepository.findByCarriageInOrderByCarriage_IdAscRowNumberAscColumnCodeAsc(carriages);
+    }
+
+    private List<Long> getAllSeatIds(Train train) {
+        return getAllSeats(train).stream().map(Seat::getId).toList();
+    }
+
+    private TrainInfoDTO findTrain(TrainSearchResponseDTO res, String trainCode) {
+        return res.getTrains().stream()
+            .filter(t -> trainCode.equals(t.getTrainCode()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("응답에서 " + trainCode + " 열차를 찾지 못함"));
+    }
+
+
+    private static class HoldMeta {
+        final long trainRunId;
+        final long seatId;
+        final int departureOrder;
+        final int arrivalOrder;
+
+        HoldMeta(long trainRunId, long seatId, int departureOrder, int arrivalOrder) {
+            this.trainRunId = trainRunId;
+            this.seatId = seatId;
+            this.departureOrder = departureOrder;
+            this.arrivalOrder = arrivalOrder;
+        }
+    }
+
+}


### PR DESCRIPTION
## ISSUE
[#18]
[#34]
[#35]

## 작업 내용
- Redis 구간 홀드 최적화
   -  세그먼트 키 유지 + (trainRunId, order) 인덱스 Set 추가로 조회 후보 축소
   - 인덱스 기반 multiGet 후 만료 seatId 정리 및 키 존재 검증으로 겹침 체크 정리
   - 홀드 해제 시 세그먼트 키 삭제 + 인덱스 Set에서도 seatId 제거/정리

- TrainRun 조회 성능 개선
  - TrainRunSearchRow DTO 프로젝션으로 불필요 엔티티 로딩 제거
  - 좌석/예약 집계를 엔티티 대신 id 기반 쿼리로 변경

- 테스트 추가
  - TrainService.searchTrain soldout 판정 테스트(예약/홀드, 겹침/경계선 비겹침 케이스) 추가

## 기타 사항
홀드 인덱스는 조회 시 만료 데이터 정리(청소)하도록 구성되어 있어, 운영에서 인덱스 누적 가능성은 모니터링 필요